### PR TITLE
test: add excelToDate utility tests

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -5,6 +5,7 @@
 import React, { useEffect, useMemo, useRef, useState } from "react";
 import { GoogleMap, useJsApiLoader, Polyline, Marker, TrafficLayer } from "@react-google-maps/api";
 import * as XLSX from "xlsx";
+import { excelToDate } from "./utils/excelToDate.js";
 
 const COLS = {
   driver: "Drivers",
@@ -27,25 +28,6 @@ const COLS = {
   receiverArrival: "Receiver Arrival Status",
 };
 
-// Convert Excel serial date or string date into a JavaScript Date object.
-// The previous implementation constructed Date objects in the local timezone
-// which could yield off‑by‑one results for users outside UTC when the string
-// was parsed as UTC. By explicitly using UTC for serial numbers and parsing
-// string dates as local midnight, we avoid unintended timezone shifts.
-const excelToDate = (v) => {
-  if (v === null || v === undefined || v === "") return null;
-  if (typeof v === "number") {
-    // Excel serial dates are based on 1899‑12‑30; treat them as UTC to avoid
-    // local timezone offsets influencing the result.
-    const base = Date.UTC(1899, 11, 30);
-    return new Date(base + v * 86400000);
-  }
-  const onlyDate = String(v).split(" ")[0];
-  // Parse string dates as local time by appending a time component so they are
-  // not interpreted as UTC. This prevents a potential one‑day shift.
-  const d = new Date(`${onlyDate}T00:00:00`);
-  return isNaN(d.getTime()) ? null : d;
-};
 const isCanceled = (s) => s && /cancel+ed|cancelled|canceled/i.test(String(s));
 const isLate = (s) => s && /late/i.test(String(s));
 const money = (n) => (isFinite(n) ? n.toLocaleString(undefined, { style: "currency", currency: "USD", maximumFractionDigits: 0 }) : "$0");

--- a/src/__tests__/excelToDate.test.js
+++ b/src/__tests__/excelToDate.test.js
@@ -1,0 +1,27 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { excelToDate } from '../utils/excelToDate.js';
+
+test('converts Excel serial numbers to Date objects', () => {
+  const d = excelToDate(45239);
+  assert.ok(d instanceof Date);
+  assert.equal(d.toISOString().slice(0,10), '2023-11-09');
+});
+
+test('parses date strings without time portion', () => {
+  const d = excelToDate('2023-11-09');
+  assert.ok(d instanceof Date);
+  assert.equal(d.toISOString().slice(0,10), '2023-11-09');
+});
+
+test('parses date strings with time portion', () => {
+  const d = excelToDate('2023-11-09 13:45');
+  assert.ok(d instanceof Date);
+  assert.equal(d.toISOString().slice(0,10), '2023-11-09');
+});
+
+test('returns null for invalid or empty inputs', () => {
+  assert.equal(excelToDate(''), null);
+  assert.equal(excelToDate(null), null);
+  assert.equal(excelToDate('not-a-date'), null);
+});

--- a/src/utils/excelToDate.js
+++ b/src/utils/excelToDate.js
@@ -1,0 +1,16 @@
+// Utility to convert Excel serial dates or date strings into JavaScript Date objects.
+// Exported for reuse and testing.
+export function excelToDate(v) {
+  if (v === null || v === undefined || v === "") return null;
+  if (typeof v === "number") {
+    // Excel serial dates are based on 1899-12-30; treat them as UTC to avoid
+    // local timezone offsets influencing the result.
+    const base = Date.UTC(1899, 11, 30);
+    return new Date(base + v * 86400000);
+  }
+  const onlyDate = String(v).split(" ")[0];
+  // Parse string dates as local time by appending a time component so they are
+  // not interpreted as UTC. This prevents a potential one-day shift.
+  const d = new Date(`${onlyDate}T00:00:00`);
+  return isNaN(d.getTime()) ? null : d;
+}


### PR DESCRIPTION
## Summary
- factor out `excelToDate` utility for reuse
- add tests covering serial numbers, date strings, and invalid inputs

## Testing
- `node --test`


------
https://chatgpt.com/codex/tasks/task_e_689a9c9b14f483229ec48e38de99ee40