### PR TITLE
docs: clarify sort order fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Visual & UX
 
 Data & Logic
 - Revenue from **Hauling Fee**; **RPM = Hauling Fee / Miles**.
-- Sorted by **Ship Date** (fallback Delivery).
+- Sorted by **Ship Date** (fallback to Delivery).
 - Date filter basis: **Pickup** or **Delivery**.
 - On‑Time when neither Shipper nor Receiver arrival contains “late”.
 - Canceled loads excluded.


### PR DESCRIPTION
## Summary
- clarify data sort order uses Ship Date, falls back to Delivery

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_689a9c970960832284b2098d309d7baa