### PR TITLE
Implement lanes API with Express and PostgreSQL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+.env
+dist/
+package-lock.json

--- a/package.json
+++ b/package.json
@@ -14,7 +14,10 @@
     "framer-motion": "^11.2.6",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "xlsx": "^0.18.5"
+    "xlsx": "^0.18.5",
+    "express": "^4.18.2",
+    "pg": "^8.11.3",
+    "zod": "^3.23.8"
   },
   "devDependencies": {
     "@types/react": "^18.2.66",
@@ -23,6 +26,8 @@
     "autoprefixer": "^10.4.19",
     "postcss": "^8.4.38",
     "tailwindcss": "^3.4.4",
-    "vite": "^5.2.0"
+    "vite": "^5.2.0",
+    "@types/express": "^4.17.21",
+    "@types/node": "^20.11.17"
   }
 }

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,0 +1,20 @@
+import express from 'express';
+import { Pool } from 'pg';
+import lanesRouter from './routes/lanes';
+
+const app = express();
+
+const pool = new Pool({
+  connectionString: process.env.DATABASE_URL,
+});
+
+app.use(express.json());
+
+app.use('/api/lanes', lanesRouter(pool));
+
+const port = Number(process.env.PORT) || 3000;
+app.listen(port, () => {
+  console.log(`Server listening on port ${port}`);
+});
+
+export default app;

--- a/server/routes/lanes.ts
+++ b/server/routes/lanes.ts
@@ -1,0 +1,104 @@
+import { Router } from 'express';
+import { Pool } from 'pg';
+
+export default function lanesRouter(pool: Pool) {
+  const router = Router();
+
+  router.get('/', async (req, res) => {
+    const { basis = 'revenue', start, end } = req.query as Record<string, string>;
+    const drivers = req.query['drivers[]'] || req.query.drivers;
+
+    if (!start || !end) {
+      return res.status(400).json({ error: 'start and end are required' });
+    }
+    if (basis !== 'revenue' && basis !== 'loads') {
+      return res.status(400).json({ error: 'basis must be revenue or loads' });
+    }
+
+    const startDate = new Date(start);
+    const endDate = new Date(end);
+    if (isNaN(startDate.getTime()) || isNaN(endDate.getTime())) {
+      return res.status(400).json({ error: 'invalid start or end date' });
+    }
+
+    let driverIds: number[] = [];
+    if (drivers) {
+      const arr = Array.isArray(drivers) ? drivers : [drivers];
+      for (const d of arr) {
+        const id = Number(d);
+        if (Number.isNaN(id)) {
+          return res.status(400).json({ error: 'drivers must be numeric' });
+        }
+        driverIds.push(id);
+      }
+    }
+
+    const values = [start, end];
+    let driverClause = '';
+    if (driverIds.length) {
+      values.push(driverIds);
+      driverClause = `AND driver_id = ANY($${values.length})`;
+    }
+
+    const query = `
+      WITH filtered AS (
+        SELECT origin_city, origin_state, dest_city, dest_state, revenue, driver_id, delivered_date
+        FROM loads
+        WHERE status = 'completed'
+          AND delivered_date BETWEEN $1 AND $2
+          ${driverClause}
+      ),
+      normalized AS (
+        SELECT
+          CASE WHEN origin_city < dest_city THEN origin_city ELSE dest_city END AS origin_city,
+          CASE WHEN origin_state < dest_state THEN origin_state ELSE dest_state END AS origin_state,
+          CASE WHEN origin_city < dest_city THEN dest_city ELSE origin_city END AS dest_city,
+          CASE WHEN origin_state < dest_state THEN dest_state ELSE origin_state END AS dest_state,
+          revenue
+        FROM filtered
+      ),
+      lane_totals AS (
+        SELECT origin_city, origin_state, dest_city, dest_state,
+               SUM(revenue) AS revenue,
+               COUNT(*) AS loads
+        FROM normalized
+        GROUP BY 1,2,3,4
+      ),
+      fleet_totals AS (
+        SELECT SUM(revenue) AS fleet_revenue, SUM(loads) AS fleet_loads FROM lane_totals
+      ),
+      ranked AS (
+        SELECT lt.*, 
+               CASE WHEN '${basis}' = 'revenue' THEN lt.revenue ELSE lt.loads END AS basis_value,
+               CASE WHEN '${basis}' = 'revenue'
+                    THEN lt.revenue / ft.fleet_revenue
+                    ELSE lt.loads::float / ft.fleet_loads
+               END AS share,
+               CASE WHEN '${basis}' = 'revenue'
+                    THEN SUM(lt.revenue) OVER (ORDER BY lt.revenue DESC) / ft.fleet_revenue
+                    ELSE SUM(lt.loads) OVER (ORDER BY lt.loads DESC) / ft.fleet_loads
+               END AS cumulative_share
+        FROM lane_totals lt CROSS JOIN fleet_totals ft
+      )
+      SELECT origin_city, origin_state, dest_city, dest_state, revenue, loads, share,
+             cumulative_share <= 0.8 AS pareto, fleet_revenue
+      FROM ranked CROSS JOIN fleet_totals
+      ORDER BY basis_value DESC;`;
+
+    try {
+      const result = await pool.query(query, values);
+      const fleetRevenue = result.rows.length ? result.rows[0].fleet_revenue : 0;
+      const rows = result.rows.map(({ fleet_revenue, ...row }) => row);
+      res.json({
+        filters: { basis, start, end, drivers: driverIds },
+        rows,
+        fleet_revenue: fleetRevenue,
+      });
+    } catch (err) {
+      console.error(err);
+      res.status(500).json({ error: 'internal error' });
+    }
+  });
+
+  return router;
+}


### PR DESCRIPTION
## Summary
- set up Express server with PostgreSQL pool
- add `/api/lanes` route that groups completed loads by lane and calculates revenue share and Pareto flag
- add Express, pg, and zod dependencies

## Testing
- `npm install --registry=https://registry.npmjs.org` (fails: 403 Forbidden for @types/express)
- `npx tsc --noEmit server/index.ts server/routes/lanes.ts` (errors: missing modules and lib definitions)
- `npm test` (fails: Missing script: "test")

------
https://chatgpt.com/codex/tasks/task_e_689aa5aa8a2c8322bbfb5e6eb5fa68ad