### PR TITLE
Add lane and RPM utilities with tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+dist/
+package-lock.json

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -1,0 +1,14 @@
+/** @type {import('ts-jest').JestConfigWithTsJest} */
+module.exports = {
+  preset: 'ts-jest/presets/default-esm',
+  testEnvironment: 'node',
+  extensionsToTreatAsEsm: ['.ts'],
+  globals: {
+    'ts-jest': {
+      useESM: true,
+    },
+  },
+  moduleNameMapper: {
+    '^(\\.{1,2}/.*)\\.js$': '$1',
+  },
+};

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "jest"
   },
   "dependencies": {
     "@googlemaps/markerclusterer": "^2.5.3",
@@ -23,6 +24,10 @@
     "autoprefixer": "^10.4.19",
     "postcss": "^8.4.38",
     "tailwindcss": "^3.4.4",
-    "vite": "^5.2.0"
+    "vite": "^5.2.0",
+    "@types/jest": "^29.5.11",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.1.1",
+    "typescript": "^5.4.2"
   }
 }

--- a/server/__tests__/lane.test.ts
+++ b/server/__tests__/lane.test.ts
@@ -1,0 +1,17 @@
+import { normalizeCity, normalizeState, laneKey } from '../utils/lane.js';
+
+describe('lane utils', () => {
+  test('normalizeCity trims and uppercases', () => {
+    expect(normalizeCity('  Kansas City  ')).toBe('KANSAS CITY');
+  });
+
+  test('normalizeState uppercases', () => {
+    expect(normalizeState('mo')).toBe('MO');
+  });
+
+  test('laneKey builds normalized key', () => {
+    expect(laneKey(' Kansas City ', 'Mo', 'Omaha', 'ne')).toBe(
+      'KANSAS CITY,MO-OMAHA,NE'
+    );
+  });
+});

--- a/server/__tests__/rpm.test.ts
+++ b/server/__tests__/rpm.test.ts
@@ -1,0 +1,20 @@
+import { avgRpm, Load } from '../utils/rpm.js';
+
+describe('avgRpm', () => {
+  test('calculates average revenue per mile', () => {
+    const loads: Load[] = [
+      { miles: 100, revenue: 200 },
+      { miles: 0, revenue: 100 },
+      { miles: 300, revenue: 600 },
+    ];
+    expect(avgRpm(loads)).toBeCloseTo(2);
+  });
+
+  test('returns 0 when total miles is 0', () => {
+    const loads: Load[] = [
+      { miles: 0, revenue: 100 },
+      { miles: 0, revenue: 200 },
+    ];
+    expect(avgRpm(loads)).toBe(0);
+  });
+});

--- a/server/utils/lane.ts
+++ b/server/utils/lane.ts
@@ -1,0 +1,18 @@
+export function normalizeCity(city: string): string {
+  return city.trim().toUpperCase();
+}
+
+export function normalizeState(state: string): string {
+  return state.trim().toUpperCase();
+}
+
+export function laneKey(
+  originCity: string,
+  originState: string,
+  destinationCity: string,
+  destinationState: string
+): string {
+  const origin = `${normalizeCity(originCity)},${normalizeState(originState)}`;
+  const destination = `${normalizeCity(destinationCity)},${normalizeState(destinationState)}`;
+  return `${origin}-${destination}`;
+}

--- a/server/utils/rpm.ts
+++ b/server/utils/rpm.ts
@@ -1,0 +1,18 @@
+export interface Load {
+  miles: number;
+  revenue: number;
+}
+
+export function avgRpm(loads: Load[]): number {
+  let miles = 0;
+  let revenue = 0;
+
+  for (const load of loads) {
+    if (load.miles > 0) {
+      miles += load.miles;
+      revenue += load.revenue;
+    }
+  }
+
+  return miles > 0 ? revenue / miles : 0;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "skipLibCheck": true
+  },
+  "include": ["server"]
+}


### PR DESCRIPTION
## Summary
- add utility to normalize cities/states and generate lane keys
- calculate average revenue per mile while skipping zero-mile loads
- cover new utilities with Jest unit tests

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_689aa5ab9c548322b1745e097d8df1ab