### PR TITLE
feat: add Lanes tab feature flag

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -5,6 +5,7 @@
 import React, { useEffect, useMemo, useRef, useState } from "react";
 import { GoogleMap, useJsApiLoader, Polyline, Marker, TrafficLayer } from "@react-google-maps/api";
 import * as XLSX from "xlsx";
+import { LanesTabEnabled } from "./features";
 
 const COLS = {
   driver: "Drivers",
@@ -353,6 +354,9 @@ export default function App() {
       <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: 12 }}>
         <div style={{ display: "flex", gap: 8 }}>
           <button style={styles.tab(tab === "dashboard")} onClick={()=>setTab("dashboard")}>Dashboard</button>
+          {LanesTabEnabled && (
+            <button style={styles.tab(tab === "lanes")} onClick={()=>setTab("lanes")}>Lanes</button>
+          )}
           <button style={styles.tab(tab === "insights")} onClick={()=>setTab("insights")}>
             Insights <span style={styles.badgeNew}>NEW</span>
           </button>
@@ -508,6 +512,13 @@ export default function App() {
             ) : (<div style={{ display: "grid", placeItems: "center", height: "100%", color: "#a2a9bb" }}>Loading Google Maps…</div>))
             : (<div style={{ display: "grid", placeItems: "center", height: "100%", color: "#a2a9bb" }}>Paste your Google Maps API key to load the map</div>)}
           </div>
+        </div>
+      )}
+
+      {/* Lanes tab */}
+      {LanesTabEnabled && tab === "lanes" && (
+        <div style={{ ...styles.card, padding: 12 }}>
+          Lanes feature coming soon.
         </div>
       )}
 

--- a/src/features.ts
+++ b/src/features.ts
@@ -1,0 +1,1 @@
+export const LanesTabEnabled = false;


### PR DESCRIPTION
## Summary
- add feature flag file exporting `LanesTabEnabled`
- show optional Lanes tab and placeholder content when flag enabled

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689aa5acdd708322ae38c83941b64760