### PR TITLE
Restore tab and lane styling

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -338,10 +338,8 @@ export default function App() {
     page: { padding: 16, background: "#0f1115", color: "#e6e8ee", fontFamily: "Inter, system-ui, -apple-system, Segoe UI, Roboto, Helvetica Neue, Arial" },
     card: { background: "#151923", border: "1px solid #232838", borderRadius: 14 },
     muted: { color: "#a2a9bb" },
-    chip: { border: "1px solid #232838", borderRadius: 999, padding: "4px 8px", fontSize: 12, display: "inline-flex", alignItems: "center", gap: 6 },
     btn: { padding: "8px 12px", border: "1px solid #232838", borderRadius: 10, cursor: "pointer", color: "#e6e8ee", background: "transparent" },
     btnAccent: { padding: "8px 12px", borderRadius: 10, cursor: "pointer", color: "#0b0d12", background: "#D2F000", border: "1px solid #D2F000", fontWeight: 700 },
-    tab: (active) => ({ padding: "10px 14px", borderRadius: 10, cursor: "pointer", border: "1px solid #232838", background: active ? "#232838" : "transparent", color: "#e6e8ee", fontWeight: 700 }),
     badgeNew: { marginLeft: 8, background: "#D2F000", color: "#0b0d12", borderRadius: 6, padding: "2px 6px", fontSize: 11, fontWeight: 800 },
     divider: { width: 6, cursor: "col-resize", background: "#0b0d12", border: "1px solid #232838", borderRadius: 6 },
   };
@@ -351,9 +349,9 @@ export default function App() {
   return (
     <div style={styles.page}>
       <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: 12 }}>
-        <div style={{ display: "flex", gap: 8 }}>
-          <button style={styles.tab(tab === "dashboard")} onClick={()=>setTab("dashboard")}>Dashboard</button>
-          <button style={styles.tab(tab === "insights")} onClick={()=>setTab("insights")}>
+        <div className="tabs">
+          <button className={`tab${tab === "dashboard" ? " active" : ""}`} onClick={()=>setTab("dashboard")}>Dashboard</button>
+          <button className={`tab${tab === "insights" ? " active" : ""}`} onClick={()=>setTab("insights")}>
             Insights <span style={styles.badgeNew}>NEW</span>
           </button>
         </div>
@@ -466,17 +464,17 @@ export default function App() {
                   const c = colorByDriver(l.driver);
                   const deadPct = (l.miles>0) ? Math.round((l.emptyMiles||0) / l.miles * 100) : 0;
                   return (
-                    <div key={i} style={{ ...styles.card, padding: 12, borderColor: c }}>
-                      <div style={{ fontWeight: 700 }}>{l.driver} • Load {l.loadNo ?? ""}</div>
-                      <div style={{ color: "#a2a9bb", fontSize: 12 }}>{fmt(l.shipDate)} pickup • {fmt(l.delDate)} delivery — {l.originCS || "—"} → {l.destCS || "—"}</div>
-                      <div style={{ display: "flex", gap: 6, flexWrap: "wrap", marginTop: 6 }}>
-                        <span style={styles.chip}>Rev {money(l.fee)}</span>
-                        <span style={styles.chip}>Mi {num(l.miles)}</span>
-                        <span style={styles.chip}>Loaded {num(l.loadedMiles)}</span>
-                        <span style={styles.chip}>Empty {num(l.emptyMiles)}</span>
-                        <span style={styles.chip}>RPM {rpm(l.fee, l.miles)}</span>
-                        <span style={styles.chip}>On‑Time {l.onTime ? "Yes" : "No"}</span>
-                        {deadPct > 20 && <span style={{ ...styles.chip, borderColor: "#ef4444", color: "#ef4444" }}>High Deadhead {deadPct}%</span>}
+                    <div key={i} className="lane-card card" style={{ borderColor: c }}>
+                      <div className="lane-title">{l.driver} • Load {l.loadNo ?? ""}</div>
+                      <div className="lane-sub">{fmt(l.shipDate)} pickup • {fmt(l.delDate)} delivery — {l.originCS || "—"} → {l.destCS || "—"}</div>
+                      <div className="lane-chips">
+                        <span className="chip">Rev {money(l.fee)}</span>
+                        <span className="chip">Mi {num(l.miles)}</span>
+                        <span className="chip">Loaded {num(l.loadedMiles)}</span>
+                        <span className="chip">Empty {num(l.emptyMiles)}</span>
+                        <span className="chip">RPM {rpm(l.fee, l.miles)}</span>
+                        <span className="chip">On‑Time {l.onTime ? "Yes" : "No"}</span>
+                        {deadPct > 20 && <span className="chip chip-alert">High Deadhead {deadPct}%</span>}
                       </div>
                     </div>
                   );

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -1,2 +1,131 @@
-/* v2.1.6 hotfix */
-/* v2.1.8 date-basis patch */
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+/* Base theme variables */
+:root {
+  --bg: #0f1115;
+  --card: #151923;
+  --muted: #8b93a7;
+  --border: #232838;
+  --accent: #D2F000;
+  --text: #e6e8ee;
+  --text-inv: #0b0d12;
+  --leftWidth: 400px;
+}
+* { box-sizing: border-box; }
+html, body, #root { height: 100%; }
+body {
+  margin: 0;
+  background: var(--bg);
+  color: var(--text);
+  font-family: Inter, system-ui, -apple-system, Segoe UI, Roboto, Arial;
+}
+.card {
+  background: var(--card);
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  box-shadow: 0 8px 20px rgba(0,0,0,.25);
+}
+input, select, button, .chip {
+  border-radius: 10px;
+  border: 1px solid var(--border);
+  background: transparent;
+  color: var(--text);
+  outline: none;
+}
+input::placeholder { color: var(--muted); }
+button.btn {
+  padding: 8px 12px;
+  cursor: pointer;
+  transition: transform .06s ease;
+}
+button.btn:active { transform: translateY(1px); }
+.btn-accent {
+  background: var(--accent);
+  color: var(--text-inv);
+  border-color: var(--accent);
+  font-weight: 700;
+}
+.badge {
+  background: var(--accent);
+  color: var(--text-inv);
+  font-weight: 800;
+  width: 22px;
+  height: 22px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 999px;
+}
+.row { display: flex; gap: 12px; align-items: center; }
+.col { display: flex; flex-direction: column; gap: 8px; }
+.kpi { padding: 14px; }
+.kpi .label { color: var(--muted); font-size: 12px; }
+.kpi .value { font-size: 20px; font-weight: 800; }
+
+/* Tab layout */
+.tabs { display: flex; gap: 8px; }
+.tab {
+  padding: 10px 14px;
+  border-radius: 10px;
+  cursor: pointer;
+  border: 1px solid var(--border);
+  background: transparent;
+  color: var(--text);
+  font-weight: 700;
+}
+.tab.active { background: var(--border); }
+
+/* Lane view */
+.lane-card { padding: 12px; }
+.lane-title { font-weight: 700; }
+.lane-sub { color: var(--muted); font-size: 12px; }
+.lane-chips { display: flex; flex-wrap: wrap; gap: 6px; margin-top: 6px; }
+.chip { padding: 4px 8px; font-size: 12px; color: var(--text); }
+.chip-alert { border-color: #ef4444; color: #ef4444; }
+
+.header { display: flex; align-items: center; justify-content: space-between; margin-bottom: 10px; }
+.header h1 { font-size: 18px; margin: 0; }
+.header .right { display: flex; gap: 8px; }
+.topbar { display: grid; grid-template-columns: repeat(5, minmax(0, 1fr)); gap: 8px; margin-bottom: 8px; }
+@media (max-width: 900px) { .topbar { grid-template-columns: 1fr 1fr; } }
+.list { display: flex; flex-direction: column; gap: 10px; }
+
+/* Split layout with draggable divider */
+.split {
+  display: grid;
+  grid-template-columns: var(--leftWidth) 6px 1fr;
+  gap: 12px;
+  align-items: stretch;
+}
+.divider {
+  background: linear-gradient(180deg, #1f2433, #1a1f2d);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  cursor: col-resize;
+  position: relative;
+}
+.divider::after {
+  content: "";
+  position: absolute;
+  left: 50%; top: 50%; transform: translate(-50%, -50%);
+  width: 2px; height: 32px; background: #2f364a; border-radius: 2px;
+}
+@media (max-width: 1100px) {
+  .split { grid-template-columns: 1fr; }
+  .divider { display: none; }
+}
+.map-shell { height: var(--mapHeight, 72vh); border-radius: 14px; overflow: hidden; }
+.legend {
+  position: absolute;
+  left: 18px;
+  bottom: 18px;
+  padding: 8px 10px;
+  background: rgba(15,17,21,.9);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  color: var(--text);
+  font-size: 12px;
+}
+hr.sep { border: none; border-top: 1px solid var(--border); margin: 8px 0; }


### PR DESCRIPTION
## Summary
- Reinstate base theme, tab, and lane view styles in index.css
- Apply matching tab and lane classes in App component
- Confirm production build includes restored styles

## Testing
- `npm run build`
- `grep -o 'lane-card' dist/assets/index-*.css`
- `grep -o 'tab.active' dist/assets/index-*.css`


------
https://chatgpt.com/codex/tasks/task_e_689ab2dca10883229360a7a374edc440