### PR TITLE
Add cancellation logic to geocoding effect

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -280,10 +280,12 @@ export default function App() {
   useEffect(()=>setMapHeight(Math.max(420, Math.min(820, 420 + legs.length*18))),[legs.length]);
   useEffect(() => {
     if (!isLoaded) return;
+    let cancelled = false;
     const geocoder = new google.maps.Geocoder();
     (async () => {
       const out = [];
       for (const l of legs) {
+        if (cancelled) break;
         if (!l.originFull || !l.destFull) continue;
         try {
           const [o, d] = await Promise.all([
@@ -297,9 +299,10 @@ export default function App() {
         } catch {}
         await new Promise(r=>setTimeout(r,80));
       }
-      setEndpoints(out);
+      if (!cancelled) setEndpoints(out);
     })();
-  }, [isLoaded, JSON.stringify(legs.map(l=>[l.originFull,l.destFull,l.driver]))]);
+    return () => { cancelled = true; };
+  }, [isLoaded, legs]);
 
   useEffect(() => {
     if (!isLoaded || !mapRef.current || !endpoints.length) return;


### PR DESCRIPTION
## Summary
- Cancel geocoding loop when component unmounts or dependencies change
- Simplify geocoding effect dependencies to `legs`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689ab8c0fd0c832282fd39d636d989c1