### PR TITLE
Cancel ongoing geocoding when component updates or unmounts

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -294,10 +294,12 @@ export default function App() {
   useEffect(()=>setMapHeight(Math.max(420, Math.min(820, 420 + legs.length*18))),[legs.length]);
   useEffect(() => {
     if (!isLoaded) return;
+    let cancelled = false;
     const geocoder = new google.maps.Geocoder();
     (async () => {
       const out = [];
       for (const l of legs) {
+        if (cancelled) break;
         if (!l.originFull || !l.destFull) continue;
         try {
           const [o, d] = await Promise.all([
@@ -311,9 +313,10 @@ export default function App() {
         } catch {}
         await new Promise(r=>setTimeout(r,80));
       }
-      setEndpoints(out);
+      if (!cancelled) setEndpoints(out);
     })();
-  }, [isLoaded, JSON.stringify(legs.map(l=>[l.originFull,l.destFull,l.driver]))]);
+    return () => { cancelled = true; };
+  }, [isLoaded, legs]);
 
   useEffect(() => {
     if (!isLoaded || !mapRef.current || !endpoints.length) return;


### PR DESCRIPTION
## Summary
- add cancellation flag to geocoding effect so loops stop when dependencies change or component unmounts
- only update endpoints when still active and replace stringified legs dependency with direct legs array

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689abf01e38083228ba6fe3ffe48719b