### PR TITLE
Handle load cancellation status in finance joiner

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+dist/
+package-lock.json

--- a/src/utils/financeJoiner.ts
+++ b/src/utils/financeJoiner.ts
@@ -1,0 +1,44 @@
+export interface LoadRow {
+  truck: string;
+  revenue?: number;
+  status: string;
+}
+
+const STATUS_COLUMNS = [
+  'Load Status',
+  'Status',
+  'Receiver Arrival Status'
+];
+
+/**
+ * Convert raw spreadsheet rows into normalized LoadRow objects.
+ * Rows without a truck or with a cancelled status are removed.
+ */
+export function normalizeLoads(rows: Record<string, any>[]): LoadRow[] {
+  return rows
+    .map((row) => {
+      const statusEntry =
+        STATUS_COLUMNS.map((col) => row[col]).find((v) => v != null && v !== '') ?? '';
+
+      return {
+        truck: row['Truck'] || row['Truck #'] || row['Truck Number'] || '',
+        revenue: Number(
+          row['Revenue'] ?? row['Carrier Revenue'] ?? row['Carrier Line Haul'] ?? 0
+        ),
+        status: String(statusEntry)
+      };
+    })
+    .filter(({ truck, status }) => !!truck && !/cancel/i.test(status));
+}
+
+/**
+ * Aggregate revenue for a list of loads, skipping cancelled loads.
+ */
+export function buildFinance(loads: LoadRow[]): number {
+  return loads.reduce((total, load) => {
+    if (/cancel/i.test(load.status)) {
+      return total;
+    }
+    return total + (load.revenue ?? 0);
+  }, 0);
+}


### PR DESCRIPTION
## Summary
- track load status in LoadRow and normalizeLoads
- ignore loads marked as cancelled during normalization and revenue aggregation
- add repository .gitignore

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689c1a5184d88322bc6b3f089a0e73e2